### PR TITLE
Move networking requests to coroutines instead of callbacks

### DIFF
--- a/data/DataController.py
+++ b/data/DataController.py
@@ -62,39 +62,39 @@ class DataController:
             return await self.offline_data_storage.get_user_data()
 
     async def get_product_data(self) -> Dict[str, List[Product]]:
-    """
-    Get a list of all products in their corresponding categories. Note that this is an asynchronous method and needs
-    to be awaited!
+        """
+        Get a list of all products in their corresponding categories. Note that this is an asynchronous method and needs
+        to be awaited!
 
-    :return: a dictionary is returned where the key is a category name and the value a list of products in that category
-    """
-    if self.running_in_online_mode():
-        return await self.online_data_storage.get_product_data()
-    else:
-        return await self.offline_data_storage.get_product_data()
+        :return: a dictionary is returned where the key is a category name and the value a list of products in that category
+        """
+        if self.running_in_online_mode():
+            return await self.online_data_storage.get_product_data()
+        else:
+            return await self.offline_data_storage.get_product_data()
 
     async def get_category_data(self) -> List[str]:
-    """
-    Get a list of all categories Note that this is an asynchronous method and needs to be awaited!
+        """
+        Get a list of all categories Note that this is an asynchronous method and needs to be awaited!
 
-    :return: a list of categories
-    """
-    if self.running_in_online_mode():
-        return await self.online_data_storage.get_category_data()
-    else:
-        return await self.offline_data_storage.get_category_data()
+        :return: a list of categories
+        """
+        if self.running_in_online_mode():
+            return await self.online_data_storage.get_category_data()
+        else:
+            return await self.offline_data_storage.get_category_data()
 
     async def get_card_info(self, card_id) -> Optional[NFCCardInfo]:
-    """
-    Get info of a particular card. Note that this method is asynchronous and thus needs to be awaited.
+        """
+        Get info of a particular card. Note that this method is asynchronous and thus needs to be awaited.
 
-    The card info will be returned as a `NFCCardInfo` object.
+        The card info will be returned as a `NFCCardInfo` object.
 
-    :param card_id: Id of the card to look for
-    :return: a `NFCCardInfo` object if matching the given ``card_id`` or None if nothing could be found
-    """
-    if self.running_in_online_mode():
-        return await self.online_data_storage.get_card_info(card_id=card_id)
+        :param card_id: Id of the card to look for
+        :return: a `NFCCardInfo` object if matching the given ``card_id`` or None if nothing could be found
+        """
+        if self.running_in_online_mode():
+            return await self.online_data_storage.get_card_info(card_id=card_id)
         else:
             return await self.offline_data_storage.get_card_info(card_id=card_id)
 
@@ -120,7 +120,6 @@ class DataController:
         :param shopping_cart: Shopping cart that has all transactions you want to create
         :return: Whether the transactions have been registered (true) or not (false).
         """
-
         if self.running_in_online_mode():
             return await self.online_data_storage.create_transactions(shopping_cart=shopping_cart)
         else:
@@ -294,10 +293,6 @@ class DataController:
         with open(OfflineDataStorage.PENDING_DATA_FILE_NAME, "w") as data_file:
             json.dump(json_data_to_write, data_file, indent=4)
 
-    # Get whether we can connect to the backend or not
-    def running_in_online_mode(self) -> bool:
-        return self.can_use_online_database
-
     # Run the setup procedure, i.e. check whether we can connect to remote server
     # If we can connect, we start authentication, otherwise we run in offline mode.
     # Make sure to run this method in a separate thread because it will be blocking.
@@ -339,6 +334,10 @@ class DataController:
         while True:
             await self._update_offline_storage()
             await asyncio.sleep(time_until_we_appear_again, loop=App.get_running_app().loop)
+
+    # Get whether we can connect to the backend or not
+    def running_in_online_mode(self) -> bool:
+        return self.can_use_online_database
 
     def register_connection_listener(self, connection_listener: ConnectionListener) -> None:
         """

--- a/data/DataStorage.py
+++ b/data/DataStorage.py
@@ -1,94 +1,69 @@
 from abc import abstractmethod
-from typing import List, Callable, Optional, Dict
+from typing import List, Optional, Dict
 
+from data.user.user_data import UserData
 from ds.NFCCardInfo import NFCCardInfo
 from ds.Product import Product
 from ds.ShoppingCart import ShoppingCart
 
 
 class DataStorage:
-
     @abstractmethod
-    def get_user_data(self, callback: Callable[[Optional[Dict[str, str]]], None] = None) -> None:
+    async def get_user_data(self) -> List[UserData]:
         """
-        Get a mapping of all users and their e-mail addresses. Note that you'll need to provide a callback function
-        that will be called whenever the data is available. The callback will also be called when no data is available.
+        Get a mapping of all users and their e-mail addresses. Note that this method is asynchronous and thus needs to
+        be awaited.
 
-        The user data is returned as a dictionary, where the key (str) is the username and the corresponding value (str)
-        is the associated e-mail address.
-
-        :param callback: Method called when this method is finished retrieving data. The callback will have one argument
-            that represents a dictionary of users. This might also be None!
-
-        :return: Nothing.
+        :return: a list of ``UserData`` objects.
         """
 
     @abstractmethod
-    def get_product_data(self, callback: Callable[[Optional[List[Product]]], None] = None) -> None:
+    async def get_product_data(self) -> Dict[str, List[Product]]:
         """
-        Get a list of all products. Note that you'll need to provide a callback function
-        that will be called whenever the data is available. The callback will also be called when no data is available.
+        Get a list of all products in their corresponding categories. Note that this is an asynchronous method and needs
+        to be awaited!
 
-        The product data is returned as a list, where each element corresponds to a Product object.
-
-        :param callback: Method called when this method is finished retrieving data. The callback will have one argument
-            that represents a list of products. This might also be None!
-
-        :return: Nothing.
+        :return: a dictionary is returned where the key is a category name and the value a list of products in that category
         """
         raise NotImplementedError
 
     @abstractmethod
-    def get_category_data(self, callback: Callable[[Optional[List[str]]], None] = None) -> None:
+    async def get_category_data(self) -> List[str]:
         """
-        Get a list of all categories. Note that you'll need to provide a callback function
-        that will be called whenever the data is available. The callback will also be called when no data is available.
+        Get a list of all categories. Note that this is an asynchronous method and needs to be awaited!
 
-        The category data is returned as a list, where each element is the name of category (as a string).
-
-        :param callback: Method called when this method is finished retrieving data. The callback will have one argument
-            that represents a list of categories. This might also be None!
-
-        :return: Nothing.
+        :return: a list of categories
         """
         raise NotImplementedError
 
     @abstractmethod
-    def get_card_info(self, card_id=None, callback: Callable[[Optional[NFCCardInfo]], None] = None) -> None:
+    async def get_card_info(self, card_id) -> Optional[NFCCardInfo]:
         """
-        Get info of a particular card. Note that you'll need to provide a callback function
-        that will be called whenever the data is available. The callback will also be called when no data is available.
+        Get info of a particular card. Note that this method is asynchronous and thus needs to be awaited.
 
-        The card info will be returned as a NFCCardInfo object.
+        The card info will be returned as a `NFCCardInfo` object.
 
-        :param card_id: id of the card
-        :param callback: Method called when this method is finished retrieving data. The callback will have one argument
-            that represents the card info. This might also be None!
-        :return: Nothing.
+        :param card_id: Id of the card to look for
+        :return: a `NFCCardInfo` object if matching the given ``card_id`` or None if nothing could be found
         """
         raise NotImplementedError
 
-    def register_card_info(self, card_id: str = None, email: str = None, owner: str = None,
-                           callback: [[bool], None] = None) -> None:
+    async def register_card_info(self, card_id: str = None, email: str = None, owner: str = None) -> bool:
         """
         Register a new card for a particular user.
+
         :param card_id: Id of the card that you want to register
         :param email: E-mail address of the user that you want to match this card with.
         :param owner: Name of the owner of the card
-        :param callback: Method called when this method is finished. The callback will have one argument (boolean)
-            that indicates whether the card has been registered (true) or not (false).
-        :return: Nothing
+        :return: Whether the card has been registered (true) or not (false).
         """
         raise NotImplementedError
 
-    def create_transactions(self, shopping_cart: ShoppingCart = None, callback: Callable[[bool], None] = None) -> None:
+    async def create_transactions(self, shopping_cart: ShoppingCart = None) -> bool:
         """
-        Create a transaction (or multiple) of goods. Note that you'll need to provide a callback function
-        that will be called whenever the call is completed.
+        Create a transaction (or multiple) of goods.
 
         :param shopping_cart: Shopping cart that has all transactions you want to create
-        :param callback: Method called when this method is finished. The callback will have one argument (boolean)
-            that indicates whether the transactions have been registered (true) or not (false).
-        :return: Nothing
+        :return: Whether the transactions have been registered (true) or not (false).
         """
         raise NotImplementedError

--- a/data/OfflineDataStorage.py
+++ b/data/OfflineDataStorage.py
@@ -71,7 +71,7 @@ class OfflineDataStorage(DataStorage):
 
     async def get_product_data(self) -> Dict[str, List[Product]]:
         if len(self.cached_data_storage.cached_product_data) > 0:
-            Logger.debug("StellaPayUI: Using online (cached) product data")
+            Logger.debug("StellaPayUI: Using offline (cached) product data")
             # Return cached product data
             return self.cached_data_storage.cached_product_data
 

--- a/data/OnlineDataStorage.py
+++ b/data/OnlineDataStorage.py
@@ -1,13 +1,14 @@
 import threading
 import traceback
 from collections import OrderedDict
-from typing import Callable, Optional, List, Dict
+from typing import Optional, List, Dict
 
 from kivy import Logger
 from kivy.app import App
 
 from data.CachedDataStorage import CachedDataStorage
 from data.DataStorage import DataStorage
+from data.user.user_data import UserData
 from ds.NFCCardInfo import NFCCardInfo
 from ds.Product import Product
 from ds.ShoppingCart import ShoppingCart
@@ -15,62 +16,91 @@ from utils import Connections
 
 
 class OnlineDataStorage(DataStorage):
-
     def __init__(self, cached_data_storage: CachedDataStorage):
         self.cached_data_storage = cached_data_storage
 
-    def get_user_data(self, callback: Callable[[Optional[Dict[str, str]]], None] = None) -> None:
+    # def get_user_data(self, callback: Callable[[Optional[Dict[str, str]]], None] = None) -> None:
+    #
+    #     # We're not doing any work when the result is ignored anyway.
+    #     if callback is None:
+    #         return
+    #
+    #     if len(self.cached_data_storage.cached_user_data) > 0:
+    #         Logger.debug("StellaPayUI: Using online (cached) user data")
+    #         # Return cached user data
+    #         callback(self.cached_data_storage.cached_user_data)
+    #         return
+    #
+    #     Logger.debug(f"StellaPayUI: Loading user mapping on thread {threading.current_thread().name}")
+    #
+    #     user_data = App.get_running_app().session_manager.do_get_request(url=Connections.get_users())
+    #
+    #     if user_data and user_data.ok:
+    #         # convert to json
+    #         user_json = user_data.json()
+    #
+    #         # append json to list and sort the list
+    #         for user in user_json:
+    #             # store all emails addressed in the sheet_menu
+    #             self.cached_data_storage.cached_user_data[user["name"]] = user["email"]
+    #
+    #         # Sort items
+    #         self.cached_data_storage.cached_user_data = OrderedDict(
+    #             sorted(self.cached_data_storage.cached_user_data.items()))
+    #
+    #         Logger.debug("StellaPayUI: Loaded user data")
+    #
+    #         callback(self.cached_data_storage.cached_user_data)
+    #     else:
+    #         Logger.critical("StellaPayUI: Error: users could not be fetched from the online database")
+    #         callback(None)
 
-        # We're not doing any work when the result is ignored anyway.
-        if callback is None:
-            return
+    async def get_user_data(self) -> List[UserData]:
+        # Check if we have no data in the cache
+        if len(self.cached_data_storage.cached_user_data) <= 0:
+            Logger.debug(f"StellaPayUI: Loading user mapping on thread {threading.current_thread().name}")
 
-        if len(self.cached_data_storage.cached_user_data) > 0:
+            # Fetch data from server and put it into the cache
+            user_data = await App.get_running_app().session_manager.do_get_request_async(url=Connections.get_users())
+
+            if user_data is not None and user_data.ok:
+                # convert to json
+                user_json = user_data.json()
+
+                # append json to list and sort the list
+                for user in user_json:
+                    # store all emails addressed in the sheet_menu
+                    self.cached_data_storage.cached_user_data[user["name"]] = user["email"]
+
+                # Sort items
+                self.cached_data_storage.cached_user_data = OrderedDict(
+                    sorted(self.cached_data_storage.cached_user_data.items())
+                )
+
+                Logger.debug("StellaPayUI: Loaded user data")
+            else:
+                Logger.critical("StellaPayUI: Error: users could not be fetched from the online database")
+                return []
+
+        else:  # We already have a cache, so use that instead.
             Logger.debug("StellaPayUI: Using online (cached) user data")
-            # Return cached user data
-            callback(self.cached_data_storage.cached_user_data)
-            return
 
-        Logger.debug(f"StellaPayUI: Loading user mapping on thread {threading.current_thread().name}")
+        # Return cached user data
+        return [
+            UserData(real_name=user_name, email_address=user_email)
+            for user_name, user_email in self.cached_data_storage.cached_user_data.items()
+        ]
 
-        user_data = App.get_running_app().session_manager.do_get_request(url=Connections.get_users())
-
-        if user_data and user_data.ok:
-            # convert to json
-            user_json = user_data.json()
-
-            # append json to list and sort the list
-            for user in user_json:
-                # store all emails addressed in the sheet_menu
-                self.cached_data_storage.cached_user_data[user["name"]] = user["email"]
-
-            # Sort items
-            self.cached_data_storage.cached_user_data = OrderedDict(
-                sorted(self.cached_data_storage.cached_user_data.items()))
-
-            Logger.debug("StellaPayUI: Loaded user data")
-
-            callback(self.cached_data_storage.cached_user_data)
-        else:
-            Logger.critical("StellaPayUI: Error: users could not be fetched from the online database")
-            callback(None)
-
-    def get_product_data(self, callback: Callable[[Optional[Dict[str, List[Product]]]], None] = None) -> None:
-        # We're not doing any work when the result is ignored anyway.
-        if callback is None:
-            return
-
+    async def get_product_data(self) -> Dict[str, List[Product]]:
         if len(self.cached_data_storage.cached_product_data) > 0:
             Logger.debug("StellaPayUI: Using online (cached) product data")
             # Return cached product data
-            callback(self.cached_data_storage.cached_product_data)
-            return
+            return self.cached_data_storage.cached_product_data
 
         # Check if there is category data loaded. We need that, otherwise we can't load the products.
         if len(self.cached_data_storage.cached_category_data) < 1:
             Logger.warning("StellaPayUI: Cannot load product data because there is no (cached) category data!")
-            callback(None)
-            return
+            return dict()
 
         Logger.debug(f"StellaPayUI: Loading product data on thread {threading.current_thread().name}")
 
@@ -78,7 +108,7 @@ class OnlineDataStorage(DataStorage):
         for category in self.cached_data_storage.cached_category_data:
             # Request products from each category
             request = Connections.get_products() + category
-            product_data = App.get_running_app().session_manager.do_get_request(request)
+            product_data = await App.get_running_app().session_manager.do_get_request_async(request)
 
             if product_data and product_data.ok:
                 # convert to json
@@ -89,66 +119,57 @@ class OnlineDataStorage(DataStorage):
                 # Create a product object for all products
                 for product in products:
                     # Only add the product to the list if the product must be shown
-                    if product['shown']:
+                    if product["shown"]:
                         p = Product().create_from_json(product)
                         self.cached_data_storage.cached_product_data[category].append(p)
 
             else:
                 Logger.warning(f"StellaPayUI: Error: could not fetch products for category {category}.")
-                return
+                return dict()
 
         # Make sure to call the callback with the proper data. (None if we have no data).
         if len(self.cached_data_storage.cached_product_data) > 0:
-            callback(self.cached_data_storage.cached_product_data)
+            return self.cached_data_storage.cached_product_data
         else:
-            callback(None)
+            return dict()
 
-    def get_category_data(self, callback: Callable[[Optional[List[str]]], None] = None) -> None:
-        # We're not doing any work when the result is ignored anyway.
-        if callback is None:
-            return
+    async def get_category_data(self) -> List[str]:
+        if len(self.cached_data_storage.cached_category_data) <= 0:
+            Logger.debug(f"StellaPayUI: Loading category data on thread {threading.current_thread().name}")
+            # Do request to the correct URL
+            category_data = await App.get_running_app().session_manager.do_get_request_async(
+                url=Connections.get_categories()
+            )
 
-        if len(self.cached_data_storage.cached_category_data) > 0:
+            if category_data and category_data.ok:
+                # convert to json
+                categories = category_data.json()
+
+                for category in categories:
+                    self.cached_data_storage.cached_category_data.append(str(category["name"]))
+
+                Logger.debug("StellaPayUI: Loaded category data")
+            else:
+                Logger.critical("StellaPayUI: Error: categories could not be fetched from the online database")
+        else:
             Logger.debug("StellaPayUI: Using online (cached) category data")
-            # Return cached category data
-            callback(self.cached_data_storage.cached_category_data)
-            return
 
-        Logger.debug(f"StellaPayUI: Loading category data on thread {threading.current_thread().name}")
+        return self.cached_data_storage.cached_category_data
 
-        # Do request to the correct URL
-        category_data = App.get_running_app().session_manager.do_get_request(url=Connections.get_categories())
-
-        if category_data and category_data.ok:
-            # convert to json
-            categories = category_data.json()
-
-            for category in categories:
-                self.cached_data_storage.cached_category_data.append(str(category['name']))
-
-            Logger.debug("StellaPayUI: Loaded category data")
-
-            callback(self.cached_data_storage.cached_category_data)
-        else:
-            Logger.critical("StellaPayUI: Error: categories could not be fetched from the online database")
-            callback(None)
-
-    def get_card_info(self, card_id=None, callback: Callable[[Optional[NFCCardInfo]], None] = None) -> None:
+    async def get_card_info(self, card_id=None) -> Optional[NFCCardInfo]:
 
         if card_id is None:
-            callback(None)
-            return
+            return None
 
         # Check if we have cached card info already
         if card_id in self.cached_data_storage.cached_card_info:
             # Return the cached data
-            callback(self.cached_data_storage.cached_card_info[card_id])
-            return
+            return self.cached_data_storage.cached_card_info[card_id]
 
         Logger.debug(f"StellaPayUI: Loading card data on thread {threading.current_thread().name}")
 
         # Do request to the correct URL
-        cards_data = App.get_running_app().session_manager.do_get_request(url=Connections.get_all_cards())
+        cards_data = await App.get_running_app().session_manager.do_get_request_async(url=Connections.get_all_cards())
 
         # Check if we have valid card data
         if cards_data and cards_data.ok:
@@ -171,29 +192,24 @@ class OnlineDataStorage(DataStorage):
             Logger.debug("StellaPayUI: Loaded cards data")
 
             # Return the loaded card data to the user
-            callback(self.cached_data_storage.cached_card_info.get(card_id, None))
+            return self.cached_data_storage.cached_card_info.get(card_id, None)
         else:
             Logger.critical("StellaPayUI: Error: cards could not be fetched from the online database")
-            callback(None)
+            return None
 
-    def register_card_info(self, card_id: str = None, email: str = None, owner: str = None,
-                           callback: [[bool], None] = None) -> None:
+    async def register_card_info(self, card_id: str = None, email: str = None, owner: str = None) -> bool:
         # Check if we have a card id and email
         if card_id is None or email is None:
-            if callback is not None:
-                callback(False)
-            return
+            return False
 
         # Check if they are not empty strings
         if len(card_id) < 1 or len(email) < 1:
-            if callback is not None:
-                callback(False)
-            return
+            return False
 
         # Use a POST command to add connect this UID to the user
-        request = App.get_running_app().session_manager.do_post_request(url=Connections.add_user_mapping(),
-                                                                        json_data={'card_id': card_id,
-                                                                                   'email': email})
+        request = await App.get_running_app().session_manager.do_post_request_async(
+            url=Connections.add_user_mapping(), json_data={"card_id": card_id, "email": email}
+        )
 
         Logger.debug(f"StellaPayUI: Registering new card on {threading.current_thread().name}")
 
@@ -201,30 +217,22 @@ class OnlineDataStorage(DataStorage):
         if request.ok:
             Logger.info(f"StellaPayUI: Registered new card with id {card_id} for {email}")
 
-            if callback is not None:
-                callback(True)
-            return
+            return True
         else:
             # User could not be added succesfully, give error 2.
-            Logger.warning(f"StellaPayUI: Could not register new card with id {card_id} for {owner}, error: "
-                           f"{request.text}")
+            Logger.warning(
+                f"StellaPayUI: Could not register new card with id {card_id} for {owner}, error: " f"{request.text}"
+            )
+            return False
 
-            if callback is not None:
-                callback(False)
-            return
-
-    def create_transactions(self, shopping_cart: ShoppingCart = None, callback: Callable[[bool], None] = None) -> None:
+    async def create_transactions(self, shopping_cart: ShoppingCart = None) -> bool:
         # Check if we have a shopping cart
         if shopping_cart is None:
-            if callback is not None:
-                callback(False)
-            return
+            return False
 
         # Check if the shopping cart is empty. If so, we return true (since all transactions have been registered).
         if len(shopping_cart.basket) < 1:
-            if callback is not None:
-                callback(True)
-            return
+            return True
 
         try:
             json_cart = shopping_cart.to_json()
@@ -232,26 +240,21 @@ class OnlineDataStorage(DataStorage):
             Logger.warning("StellaPayUI: There was an error while parsing the shopping cart to JSON!")
             traceback.print_exception(None, e, e.__traceback__)
 
-            if callback is not None:
-                callback(False)
-            return
+            return False
 
         # use a POST-request to forward the shopping cart
-        response = App.get_running_app().session_manager.do_post_request(url=Connections.create_transaction(),
-                                                                         json_data=json_cart)
+        response = await App.get_running_app().session_manager.do_post_request_async(
+            url=Connections.create_transaction(), json_data=json_cart
+        )
 
         # Response was okay.
         if response and response.ok:
             Logger.info(f"StellaPayUI: Registered {len(shopping_cart.basket)} transactions to the server.")
-            if callback is not None:
-                callback(True)
-            return
+            return True
         elif response is None or not response.ok:
             Logger.warning(f"StellaPayUI: Failed to register {len(shopping_cart.basket)} transactions to the server.")
             # Response was wrong
-            if callback is not None:
-                callback(False)
+            return False
         else:
             Logger.critical(f"StellaPayUI: Payment could not be made: error: {response.content}")
-            if callback is not None:
-                callback(False)
+            return False

--- a/data/OnlineDataStorage.py
+++ b/data/OnlineDataStorage.py
@@ -55,36 +55,36 @@ class OnlineDataStorage(DataStorage):
         ]
 
     async def get_product_data(self) -> Dict[str, List[Product]]:
-    # Check if we have no data in the cache
-    if len(self.cached_data_storage.cached_product_data) <= 0:
-        Logger.debug(f"StellaPayUI: Loading product data on thread {threading.current_thread().name}")
+        # Check if we have no data in the cache
+        if len(self.cached_data_storage.cached_product_data) <= 0:
+            Logger.debug(f"StellaPayUI: Loading product data on thread {threading.current_thread().name}")
 
-        # Grab products from each category
-        for category in self.cached_data_storage.cached_category_data:
-            # Request products from each category
-            request = Connections.get_products() + category
-            product_data = await App.get_running_app().session_manager.do_get_request_async(request)
+            # Grab products from each category
+            for category in self.cached_data_storage.cached_category_data:
+                # Request products from each category
+                request = Connections.get_products() + category
+                product_data = await App.get_running_app().session_manager.do_get_request_async(request)
 
-            if product_data and product_data.ok:
-                # convert to json
-                products = product_data.json()
+                if product_data and product_data.ok:
+                    # convert to json
+                    products = product_data.json()
 
-                Logger.debug(f"StellaPayUI: Retrieved {len(products)} products for category '{category}'")
+                    Logger.debug(f"StellaPayUI: Retrieved {len(products)} products for category '{category}'")
 
-                # Create a product object for all products
-                for product in products:
-                    # Only add the product to the list if the product must be shown
-                    if product["shown"]:
-                        p = Product().create_from_json(product)
-                        self.cached_data_storage.cached_product_data[category].append(p)
+                    # Create a product object for all products
+                    for product in products:
+                        # Only add the product to the list if the product must be shown
+                        if product["shown"]:
+                            p = Product().create_from_json(product)
+                            self.cached_data_storage.cached_product_data[category].append(p)
 
-            else:
-                Logger.warning(f"StellaPayUI: Error: could not fetch products for category {category}.")
-    else:  # We already have a cache, so use that instead.
-        Logger.debug("StellaPayUI: Using online (cached) product data")
+                else:
+                    Logger.warning(f"StellaPayUI: Error: could not fetch products for category {category}.")
+        else:  # We already have a cache, so use that instead.
+            Logger.debug("StellaPayUI: Using online (cached) product data")
 
-    # Return cached product data
-    return self.cached_data_storage.cached_product_data
+        # Return cached product data
+        return self.cached_data_storage.cached_product_data
 
     async def get_category_data(self) -> List[str]:
         if len(self.cached_data_storage.cached_category_data) <= 0:

--- a/data/user/user_data.py
+++ b/data/user/user_data.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class UserData:
+    """
+    A immutable data object representing a user and its data
+    """
+
+    real_name: str = ""
+    email_address: str = ""

--- a/kvs/RegisterUIDScreen.kv
+++ b/kvs/RegisterUIDScreen.kv
@@ -33,7 +33,7 @@
         pos_hint: {'center_x': 0.5, 'center_y': 0.5}
         pos_hint_x: root.center_x
         pos_hint_y: root.center_y
-        on_release: root.on_click_user_list_button()
+        on_release: root.on_open_user_selector()
 
     Label:
         id: chosen_user

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 smartcard~=0.3
 Kivy~=2.1.0
-requests~=2.27.1
+requests==2.28.2
 kivymd~=0.104.2

--- a/scrs/DefaultScreen.py
+++ b/scrs/DefaultScreen.py
@@ -166,14 +166,13 @@ class DefaultScreen(Screen):
             self.clear_recent_user(i)
 
     async def get_most_recent_users(self):
-    Logger.debug(f"StellaPayUI: Loading recent users on {threading.current_thread().name}")
+        Logger.debug(f"StellaPayUI: Loading recent users on {threading.current_thread().name}")
 
-    recent_users = await App.get_running_app().data_controller.get_recent_users(number_of_unique_users=3)
+        recent_users = await App.get_running_app().data_controller.get_recent_users(number_of_unique_users=3)
 
-    self.set_recent_users(recent_users)
+        self.set_recent_users(recent_users)
 
-
-#
+    #
     # gets called when the 'NFC kaart vergeten button' is pressed
     # Shows a dialog to select a user.
     #

--- a/scrs/DefaultScreen.py
+++ b/scrs/DefaultScreen.py
@@ -215,6 +215,7 @@ class DefaultScreen(Screen):
                 on_dismiss=self.on_user_select_dialog_close,
             )
 
+    @mainthread
     # An active user is selected via the dialog
     def selected_active_user(self, selected_user_name: Optional[str]):
         # Close the dialog screen
@@ -243,7 +244,7 @@ class DefaultScreen(Screen):
 
     @mainthread
     def nfc_card_presented(self, uid: str):
-        Logger.debug("StellaPayUI: Read NFC card with uid" + uid)
+        Logger.debug(f"StellaPayUI: Read NFC card with uid '{uid}'")
 
         # If we are currently making a transaction, ignore the card reading.
         if App.get_running_app().active_user is not None:
@@ -269,20 +270,18 @@ class DefaultScreen(Screen):
 
         if card_info is None:
             Logger.debug(f"StellaPayUI: Did not find info for card '{uid}'.")
-            # User was not found, proceed to registerUID file
-            self.manager.transition = SlideTransition(direction="right")
-            self.manager.get_screen(Screens.REGISTER_UID_SCREEN.value).nfc_id = uid
-            self.manager.current = Screens.REGISTER_UID_SCREEN.value
+
+            self.move_to_register_card_screen(uid)
         else:
             Logger.debug(f"StellaPayUI: Card '{uid}' belongs to {card_info.owner_name}.")
-            # User is found
-            App.get_running_app().active_user = card_info.owner_name
+            self.selected_active_user(card_info.owner_name)
 
-            # Set slide transition correctly.
-            self.manager.transition = SlideTransition(direction="left")
-
-            # Go to the product screen
-            self.manager.current = Screens.PRODUCT_SCREEN.value
+    @mainthread
+    def move_to_register_card_screen(self, uid: str):
+        # User was not found, proceed to registerUID file
+        self.manager.transition = SlideTransition(direction="right")
+        self.manager.get_screen(Screens.REGISTER_UID_SCREEN.value).nfc_id = uid
+        self.manager.current = Screens.REGISTER_UID_SCREEN.value
 
     def on_select_guest(self):
         self.select_special_user("Gast Account")

--- a/scrs/ProductScreen.py
+++ b/scrs/ProductScreen.py
@@ -295,7 +295,7 @@ class ProductScreen(Screen):
         self.timeout_event.cancel()
 
         self.final_dialog = MDDialog(
-            text="Gelukt! Je aankoop is geregistreerd",
+            text="Gelukt! Je aankoop is geregistreerd!",
             on_dismiss=self.on_thanks
         )
 

--- a/scrs/ProductScreen.py
+++ b/scrs/ProductScreen.py
@@ -296,9 +296,7 @@ class ProductScreen(Screen):
 
         self.final_dialog = MDDialog(
             text="Gelukt! Je aankoop is geregistreerd",
-            buttons=[
-                MDRaisedButton(text="Thanks", on_release=self.on_thanks),
-            ],
+            on_dismiss=self.on_thanks
         )
 
         self.timeout_event = Clock.schedule_once(self.on_thanks, 5)

--- a/scrs/StartupScreen.py
+++ b/scrs/StartupScreen.py
@@ -1,8 +1,7 @@
 import sys
 
 from kivy import Logger
-from kivy.app import App
-from kivy.clock import Clock
+from kivy.clock import Clock, mainthread
 from kivy.lang import Builder
 from kivy.properties import ObjectProperty
 from kivy.uix.screenmanager import Screen
@@ -11,7 +10,7 @@ from kivy.uix.screenmanager import Screen
 from utils.Screens import Screens
 from utils.async_requests.AsyncResult import AsyncResult
 
-Builder.load_file('kvs/StartupScreen.kv')
+Builder.load_file("kvs/StartupScreen.kv")
 
 
 class StartupScreen(Screen):
@@ -26,7 +25,7 @@ class StartupScreen(Screen):
     # Calls upon entry of this screen
     #
     def on_enter(self, *args):
-        App.get_running_app().loop.call_soon_threadsafe(self.check_if_all_data_is_loaded)
+        self.check_if_all_data_is_loaded()
 
     # Called when all data has loaded
     def finished_loading(self, dt):
@@ -41,8 +40,8 @@ class StartupScreen(Screen):
     def on_products_loaded(self, _, _2):
         self.check_if_all_data_is_loaded()
 
+    @mainthread
     def check_if_all_data_is_loaded(self) -> None:
-
         self.set_loading_text("Waiting for data to load... (0/3)")
 
         if self.users_loaded is None or self.users_loaded.result is None:

--- a/utils/SessionManager.py
+++ b/utils/SessionManager.py
@@ -1,10 +1,14 @@
+import functools
 import json
 import os
+import sys
+import threading
 import traceback
 from typing import Optional
 
 import requests
 from kivy import Logger
+from kivy.app import App
 
 from utils import Connections
 
@@ -28,36 +32,31 @@ class SessionManager:
     def create_authentication_file():
         # Create the authentication file if it doesn't exist.
         if not os.path.exists(SessionManager.AUTHENTICATION_FILE):
-            open(SessionManager.AUTHENTICATION_FILE, 'w').close()
+            open(SessionManager.AUTHENTICATION_FILE, "w").close()
 
-    # This method authenticates to the backend and makes the session ready for use
-    def setup_session(self, on_finish=None):
-
+    async def setup_session_async(self) -> bool:
         self.session = requests.Session()
 
-        self.__setup_authentication()
+        return await self._setup_authentication_async()
 
-        # Call callback if defined
-        if on_finish is not None:
-            on_finish()
-
-    def __setup_authentication(self) -> bool:
-        # Convert authentication.json to json dict
-
+    async def _setup_authentication_async(self) -> bool:
         json_credentials = None
 
+        # Convert authentication.json to json dict
         try:
             json_credentials = self.parse_to_json(SessionManager.AUTHENTICATION_FILE)
         except Exception:
             Logger.critical(
-                "StellaPayUI: You need to provide an 'authenticate.json' file for your backend credentials.")
-            os._exit(1)
-
-        response = None
+                "StellaPayUI: You need to provide an 'authenticate.json' file for your backend credentials."
+            )
+            sys.exit(1)
 
         # Attempt to log in
         try:
-            response = self.session.post(url=Connections.authenticate(), json=json_credentials, timeout=5)
+            post_future = App.get_running_app().loop.run_in_executor(
+                None, functools.partial(self.session.post, Connections.authenticate(), json=json_credentials, timeout=5)
+            )
+            response = await post_future
         except Exception:
             Logger.critical(f"StellaPayUI: Something went wrong while setting up authentication to the backend server!")
             return False
@@ -65,73 +64,77 @@ class SessionManager:
         # Break control flow if the user cannot identify himself
         if response is None or (response is not None and not response.ok):
             Logger.critical(
-                "StellaPayUI: Could not correctly authenticate, error code 8. Check your username and password")
+                "StellaPayUI: Could not correctly authenticate, error code 8. Check your username and password"
+            )
             return False
         else:
-            Logger.debug("StellaPayUI: Authenticated correctly to backend.")
+            Logger.debug("StellaPayUI: Authenticated correctly to backend (async).")
             return True
 
-    # Perform a get request to the given url. You can provide a callback to receive the result.
-    def do_get_request(self, url: str) -> Optional[requests.Response]:
+    async def do_get_request_async(self, url: str) -> Optional[requests.Response]:
+        Logger.debug(f"StellaPayUI: ({threading.current_thread().name}) Async GET request to {url}")
+
         if self.session is None:
             Logger.warning(f"StellaPayUI: No session was found, so initializing a session.")
-            self.session = requests.Session()
 
-            # Could not reauthenticate to the server
-            if not self.__setup_authentication():
+            if not await self.setup_session_async():
                 Logger.critical(f"StellaPayUI: Could not authenticate in new session!")
                 return None
 
         try:
-            response = self.session.get(url, timeout=5)
+            get_future = App.get_running_app().loop.run_in_executor(
+                None, functools.partial(self.session.get, url, timeout=5)
+            )
+            response = await get_future
 
             return response
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e1:
-            Logger.debug("StellaPayUI: Connection was reset, so reauthenticating...")
-
-            self.session = requests.Session()
-
-            # Could not reauthenticate to the server
-            if not self.__setup_authentication():
-                return None
-
             Logger.critical(f"StellaPayUI: Timeout on get request {e1}")
+            Logger.debug("StellaPayUI: Connection was reset, trying to reauthenticate...")
+            await self.setup_session_async()
 
-            return self.session.get(url)
+            get_future = App.get_running_app().loop.run_in_executor(
+                None, functools.partial(self.session.get, url, timeout=5)
+            )
+            response = await get_future
+
+            return response
         except Exception as e2:
             Logger.critical(f"StellaPayUI: A problem with a GET request")
             traceback.print_exception(None, e2, e2.__traceback__)
 
             return None
 
-    # Perform a post request to the given url. You can give do functions as callbacks (which will return the response)
-    def do_post_request(self, url: str, json_data=None) -> Optional[requests.Response]:
+    async def do_post_request_async(self, url: str, json_data=None) -> Optional[requests.Response]:
 
+        Logger.debug(f"StellaPayUI: ({threading.current_thread().name}) Async POST request to {url}")
         if self.session is None:
             Logger.warning(f"StellaPayUI: No session was found, so initializing a session.")
-            self.session = requests.Session()
 
-            # Could not reauthenticate to the server
-            if not self.__setup_authentication():
+            if not await self.setup_session_async():
                 Logger.critical(f"StellaPayUI: Could not authenticate in new session!")
                 return None
 
         try:
-            response = self.session.post(url, json=json_data, timeout=5)
+            post_future = App.get_running_app().loop.run_in_executor(
+                None, functools.partial(self.session.post, url, timeout=5, json=json_data)
+            )
+            response = await post_future
 
             return response
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e1:
-            Logger.debug("StellaPayUI: Connection was reset, so reauthenticating...")
-            self.session = requests.Session()
-
-            # Could not reauthenticate to the server
-            if not self.__setup_authentication():
-                return None
-
             Logger.critical(f"StellaPayUI: Timeout on post request {e1}")
+            Logger.debug("StellaPayUI: Connection was reset, trying to reauthenticate...")
+            await self.setup_session_async()
 
-            return self.session.post(url, json=json_data)
+            post_future = App.get_running_app().loop.run_in_executor(
+                None, functools.partial(self.session.post, url, timeout=5, json=json_data)
+            )
+            response = await post_future
+
+            return response
         except Exception as e2:
-            Logger.critical(f"StellaPayUI: A problem with a POST request:")
+            Logger.critical(f"StellaPayUI: A problem with a POST request")
             traceback.print_exception(None, e2, e2.__traceback__)
+
             return None

--- a/utils/SessionManager.py
+++ b/utils/SessionManager.py
@@ -40,8 +40,6 @@ class SessionManager:
         return await self._setup_authentication_async()
 
     async def _setup_authentication_async(self) -> bool:
-        json_credentials = None
-
         # Convert authentication.json to json dict
         try:
             json_credentials = self.parse_to_json(SessionManager.AUTHENTICATION_FILE)

--- a/ux/ProductListItem.py
+++ b/ux/ProductListItem.py
@@ -46,7 +46,7 @@ class ProductListItem(TwoLineAvatarIconListItem):
 
         # Create dialog if it wasn't created before.
         if price is not None:
-            App.get_running_app().loop.call_soon_threadsafe(self.load_dialog_screen)
+            self.load_dialog_screen()
 
     def on_add_product(self):
         # Let caller know that we want to add an item to the shopping cart

--- a/ux/UserPickerDialog.py
+++ b/ux/UserPickerDialog.py
@@ -1,20 +1,21 @@
 import datetime
+from typing import List
 
-from kivy.app import App
 from kivy.lang import Builder
 from kivy.properties import StringProperty
 from kivy.uix.boxlayout import BoxLayout
 from kivymd.uix.dialog import MDDialog
 
-Builder.load_file('kvs/UserPickerContent.kv')
+Builder.load_file("kvs/UserPickerContent.kv")
 
 
 class UserPickerContent(BoxLayout):
     picked_user = StringProperty()
 
-    def __init__(self, **kwargs):
+    def __init__(self, selectable_users: List[str], **kwargs):
         super(UserPickerContent, self).__init__(**kwargs)
-        self.eligible_users_to_select = list(App.get_running_app().user_mapping.keys())
+        self.eligible_users_to_select = selectable_users
+        # list(App.get_running_app().user_mapping.keys())
 
         self.last_click_registered = datetime.datetime.now()
 
@@ -26,10 +27,12 @@ class UserPickerContent(BoxLayout):
         user_name: str
         for user_name in self.eligible_users_to_select:
             if typed_text.lower() in user_name.lower():
-                self.ids.matched_users.data.append({
-                    "viewclass": "OneLineIconListItem",
-                    "text": user_name,
-                })
+                self.ids.matched_users.data.append(
+                    {
+                        "viewclass": "OneLineIconListItem",
+                        "text": user_name,
+                    }
+                )
 
         # Make sure to add listeners so we get alerted whenever a child is clicked.
         for shown_user_element in self.ids.matched_users.children[0].children:
@@ -69,9 +72,9 @@ class UserPickerDialog(MDDialog):
     If no person is selected, this property will be None.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, selectable_users: List[str], **kwargs):
         self.type = "custom"
-        self.content_cls = UserPickerContent()
+        self.content_cls = UserPickerContent(selectable_users=selectable_users)
         self.title = "Select a name"
 
         super(UserPickerDialog, self).__init__(**kwargs)


### PR DESCRIPTION
Currently our asynchronous code is run using callbacks on a separate thread. It runs fine, but is not nice to work with. This PR changes all asynchronous code to use Python's coroutines instead. The coroutines run on a separate thread so they will not block the main thread, but it is much nicer to code as we do not have to use callbacks everywhere. Instead, we can use await and async.